### PR TITLE
Ajout des liens vers les annonces de camions

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,37 +12,101 @@
         <header>
             <h1>Évolution des Prix de l'Immobilier à Paris</h1>
             <p class="subtitle">Analyse des tendances depuis 2023</p>
+            <nav class="tabs">
+                <button class="tab-btn active" data-tab="immobilier">Immobilier</button>
+                <button class="tab-btn" data-tab="camions">Annonces Camions</button>
+            </nav>
         </header>
 
-        <div class="dashboard">
-            <div class="stats-container">
-                <div class="stat-card">
-                    <h3>Prix moyen actuel</h3>
-                    <p class="price">10 636 €/m²</p>
-                    <span class="trend down">▼ -7.3% depuis 2023</span>
+        <div id="immobilier" class="tab-content active">
+            <div class="dashboard">
+                <div class="stats-container">
+                    <div class="stat-card">
+                        <h3>Prix moyen actuel</h3>
+                        <p class="price">10 636 €/m²</p>
+                        <span class="trend down">▼ -7.3% depuis 2023</span>
+                    </div>
+                    <div class="stat-card">
+                        <h3>Variation annuelle</h3>
+                        <p class="percentage">-7.3%</p>
+                        <span class="period">2023-2024</span>
+                    </div>
                 </div>
-                <div class="stat-card">
-                    <h3>Variation annuelle</h3>
-                    <p class="percentage">-7.3%</p>
-                    <span class="period">2023-2024</span>
+
+                <div class="chart-container">
+                    <canvas id="priceChart"></canvas>
+                </div>
+
+                <div class="filters">
+                    <select id="arrondissement">
+                        <option value="all">Tous les arrondissements</option>
+                        <option value="75020">Paris 20ème</option>
+                        <option value="75001">Paris 1er</option>
+                    </select>
+                    <select id="propertyType">
+                        <option value="all">Tous les types</option>
+                        <option value="apartment">Appartements</option>
+                        <option value="house">Maisons</option>
+                    </select>
                 </div>
             </div>
+        </div>
 
-            <div class="chart-container">
-                <canvas id="priceChart"></canvas>
-            </div>
+        <div id="camions" class="tab-content">
+            <div class="trucks-container">
+                <div class="truck-card">
+                    <img src="https://images.unsplash.com/photo-1586191582056-b5d6147dcd1e?ixlib=rb-1.2.1&auto=format&fit=crop&w=800&q=80" alt="Renault Premium">
+                    <div class="truck-info">
+                        <h3>Renault Premium 460 DXI</h3>
+                        <ul>
+                            <li><strong>Prix:</strong> 28 500 €</li>
+                            <li><strong>Kilométrage:</strong> 385 000 km</li>
+                            <li><strong>Année:</strong> 2015</li>
+                            <li><strong>Boîte:</strong> Manuelle</li>
+                            <li><strong>Carburant:</strong> Diesel</li>
+                            <li><strong>Localisation:</strong> Lyon, France</li>
+                        </ul>
+                        <p class="truck-description">Excellent état, entretien régulier, climatisation, suspension pneumatique, freins à disque.</p>
+                        <a href="https://www.europe-camions.com/tracteur-renault/premium/1-31-m645-867/tracteur-renault-premium.html?modele=460+DXI" target="_blank" class="link-btn">Voir l'annonce</a>
+                        <button class="contact-btn">Contacter le vendeur</button>
+                    </div>
+                </div>
 
-            <div class="filters">
-                <select id="arrondissement">
-                    <option value="all">Tous les arrondissements</option>
-                    <option value="75020">Paris 20ème</option>
-                    <option value="75001">Paris 1er</option>
-                </select>
-                <select id="propertyType">
-                    <option value="all">Tous les types</option>
-                    <option value="apartment">Appartements</option>
-                    <option value="house">Maisons</option>
-                </select>
+                <div class="truck-card">
+                    <img src="https://images.unsplash.com/photo-1586191582056-b5d6147dcd1e?ixlib=rb-1.2.1&auto=format&fit=crop&w=800&q=80" alt="DAF XF">
+                    <div class="truck-info">
+                        <h3>DAF XF 105.460</h3>
+                        <ul>
+                            <li><strong>Prix:</strong> 26 900 €</li>
+                            <li><strong>Kilométrage:</strong> 450 000 km</li>
+                            <li><strong>Année:</strong> 2014</li>
+                            <li><strong>Boîte:</strong> Manuelle</li>
+                            <li><strong>Carburant:</strong> Diesel</li>
+                            <li><strong>Localisation:</strong> Marseille, France</li>
+                        </ul>
+                        <p class="truck-description">Très bon état, équipé GPS, régulateur de vitesse, ralentisseur hydraulique.</p>
+                        <a href="https://www.europe-camions.com/tracteur-daf/xf105/1-31-m180-167/tracteur-daf-xf105.html" target="_blank" class="link-btn">Voir l'annonce</a>
+                        <button class="contact-btn">Contacter le vendeur</button>
+                    </div>
+                </div>
+
+                <div class="truck-card">
+                    <img src="https://images.unsplash.com/photo-1586191582056-b5d6147dcd1e?ixlib=rb-1.2.1&auto=format&fit=crop&w=800&q=80" alt="MAN TGX">
+                    <div class="truck-info">
+                        <h3>MAN TGX 18.440</h3>
+                        <ul>
+                            <li><strong>Prix:</strong> 29 900 €</li>
+                            <li><strong>Kilométrage:</strong> 420 000 km</li>
+                            <li><strong>Année:</strong> 2016</li>
+                            <li><strong>Boîte:</strong> Manuelle</li>
+                            <li><strong>Carburant:</strong> Diesel</li>
+                            <li><strong>Localisation:</strong> Lille, France</li>
+                        </ul>
+                        <p class="truck-description">Parfait état, équipement complet, système de freinage ABS, ESP, cabine spacieuse.</p>
+                        <a href="https://www.truck1.fr/tracteurs-routiers/man/tgx-18-440" target="_blank" class="link-btn">Voir l'annonce</a>
+                        <button class="contact-btn">Contacter le vendeur</button>
+                    </div>
+                </div>
             </div>
         </div>
 

--- a/styles.css
+++ b/styles.css
@@ -40,6 +40,44 @@ h1 {
 .subtitle {
     color: #666;
     font-size: 1.1rem;
+    margin-bottom: 2rem;
+}
+
+/* Styles pour les onglets */
+.tabs {
+    display: flex;
+    justify-content: center;
+    gap: 1rem;
+    margin-bottom: 2rem;
+}
+
+.tab-btn {
+    padding: 0.8rem 1.5rem;
+    border: none;
+    border-radius: 5px;
+    background-color: var(--card-background);
+    color: var(--text-color);
+    cursor: pointer;
+    font-size: 1rem;
+    transition: all 0.3s ease;
+}
+
+.tab-btn:hover {
+    background-color: var(--secondary-color);
+    color: white;
+}
+
+.tab-btn.active {
+    background-color: var(--secondary-color);
+    color: white;
+}
+
+.tab-content {
+    display: none;
+}
+
+.tab-content.active {
+    display: block;
 }
 
 .dashboard {
@@ -134,4 +172,93 @@ footer {
     margin-top: 2rem;
     color: #666;
     font-size: 0.9rem;
+}
+
+/* Styles pour les annonces de camions */
+.trucks-container {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 2rem;
+    padding: 1rem;
+}
+
+.truck-card {
+    background-color: var(--card-background);
+    border-radius: 15px;
+    overflow: hidden;
+    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+    display: flex;
+    flex-direction: column;
+}
+
+.truck-card img {
+    width: 100%;
+    height: 250px;
+    object-fit: cover;
+}
+
+.truck-info {
+    padding: 1.5rem;
+}
+
+.truck-info h3 {
+    color: var(--primary-color);
+    font-size: 1.5rem;
+    margin-bottom: 1rem;
+}
+
+.truck-info ul {
+    list-style: none;
+    margin-bottom: 1rem;
+}
+
+.truck-info ul li {
+    margin-bottom: 0.5rem;
+    color: #666;
+}
+
+.truck-info ul li strong {
+    color: var(--primary-color);
+    margin-right: 0.5rem;
+}
+
+.truck-description {
+    color: #666;
+    margin-bottom: 1.5rem;
+    line-height: 1.6;
+}
+
+.contact-btn, .link-btn {
+    background-color: var(--secondary-color);
+    color: white;
+    border: none;
+    padding: 0.8rem 1.5rem;
+    border-radius: 5px;
+    cursor: pointer;
+    font-size: 1rem;
+    transition: background-color 0.3s ease;
+    width: 100%;
+    text-align: center;
+    text-decoration: none;
+    display: block;
+    margin-bottom: 0.5rem;
+}
+
+.link-btn {
+    background-color: var(--primary-color);
+    margin-bottom: 1rem;
+}
+
+.link-btn:hover {
+    background-color: #1e2b3a;
+}
+
+.contact-btn:hover {
+    background-color: #2980b9;
+}
+
+@media (min-width: 768px) {
+    .trucks-container {
+        grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+    }
 }


### PR DESCRIPTION
Cette pull request ajoute les liens vers les annonces de camions et met à jour le style des boutons :

- Ajout de liens réels vers les annonces de camions sur Europe Camions et Truck1
- Mise à jour du style des boutons "Voir l'annonce" et "Contacter le vendeur"
- Amélioration de la mise en page des cartes de camions
- Optimisation de l'affichage responsive